### PR TITLE
SUPER_CLIENT xml config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,7 @@ COPY config.discovery-server.template.yaml /
 COPY config.wan.template.yaml /
 COPY filter.yaml /
 COPY config_daemon.sh /
+COPY superclient.template.xml /
 
 ENV AUTO_CONFIG=TRUE
 ENV USE_HUSARNET=TRUE

--- a/demo/auto/connecting_to_ds/super_client.sh
+++ b/demo/auto/connecting_to_ds/super_client.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+docker run --rm -it\
+  --network host \
+  -e ROS_DISCOVERY_SERVER=rosbot2r:11811 \
+  -e DISCOVERY_SERVER_ID=10 \
+  husarnet/ros2router:1.3.0 \
+  cat /var/tmp/superclient.xml | awk '/\?xml version="1.0" encoding="UTF-8" \?/,0' > superclient.xml
+
+export FASTRTPS_DEFAULT_PROFILES_FILE=$(pwd)/superclient.xml
+
+# Run ROS2 listener
+ros2 run demo_nodes_cpp listener

--- a/demo/auto/connecting_to_ds/super_client.sh
+++ b/demo/auto/connecting_to_ds/super_client.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-docker run --rm -it\
+docker run --rm -it \
   --network host \
   -e ROS_DISCOVERY_SERVER=rosbot2r:11811 \
   -e DISCOVERY_SERVER_ID=10 \

--- a/devel_setup/compose.yaml
+++ b/devel_setup/compose.yaml
@@ -5,8 +5,8 @@
 # docker compose exec dds_router bash 
 
 services:
-  dds_router:
-    image: husarnet/dds-router:v2.0.0
+  ros2router:
+    image: husarnet/ros2router:1.2.0
     restart: always
     network_mode: host
     ipc: host
@@ -17,14 +17,16 @@ services:
       - ../config_daemon.sh:/config_daemon.sh
       - ../entrypoint.sh:/entrypoint.sh
       - ./filter.yaml:/filter.yaml
+      - ../superclient.template.xml:/superclient.template.xml
+      - ../create_superclient.sh:/create_superclient.sh
       - ./test.sh:/test.sh
       - ./test2.sh:/test2.sh
     environment:
       ROS_DOMAIN_ID: 123
       ROS_DOMAIN_ID_2: 12
       ROS_DISCOVERY_SERVER: ";;;;rosbot2r:123;;;;[fc94:5fa1:c323:30bc:a87d:7485:23c4:f5a2]:9876"
-      LISTENING_PORT: "12345"
-      ID: 1
+      DISCOVERY_SERVER_LISTENING_PORT: "12345"
+      DISCOVERY_SERVER_ID: 1
       FILTER: |
         allowlist:
           - name: "rt/chatter2"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -65,16 +65,16 @@ create_config_husarnet() {
                 echo "On different hosts, set the ROS_DISCOVERY_SERVER=[$LOCAL_IP]:$DISCOVERY_SERVER_LISTENING_PORT"
 
                 ## TIP 2:
-                cp /superclient.template.xml $CFG_PATH/superclient.xml
+                cp /superclient.template.xml $CFG_PATH/superclient_single.xml
                 # Convert the decimal to a hexadecimal value
                 hex_server_id=$(printf '%.2X' $DISCOVERY_SERVER_ID)
 
                 # Replace XX in GUID_PREFIX with the hexadecimal value
                 export GUID_PREFIX=$(echo "44.53.XX.5F.45.50.52.4F.53.49.4D.41" | sed "s/XX/$hex_server_id/")
 
-                yq -i '.dds.profiles.participant.rtps.builtin.discovery_config.discoveryServersList.RemoteServer.+@prefix = env(GUID_PREFIX)' $CFG_PATH/superclient.xml
-                yq -i '.dds.profiles.participant.rtps.builtin.discovery_config.discoveryServersList.RemoteServer.metatrafficUnicastLocatorList.locator.udpv6.address = env(LOCAL_IP)' $CFG_PATH/superclient.xml
-                yq -i '.dds.profiles.participant.rtps.builtin.discovery_config.discoveryServersList.RemoteServer.metatrafficUnicastLocatorList.locator.udpv6.port = env(DISCOVERY_SERVER_LISTENING_PORT)' $CFG_PATH/superclient.xml
+                yq -i '.dds.profiles.participant.rtps.builtin.discovery_config.discoveryServersList.RemoteServer.+@prefix = env(GUID_PREFIX)' $CFG_PATH/superclient_single.xml
+                yq -i '.dds.profiles.participant.rtps.builtin.discovery_config.discoveryServersList.RemoteServer.metatrafficUnicastLocatorList.locator.udpv6.address = env(LOCAL_IP)' $CFG_PATH/superclient_single.xml
+                yq -i '.dds.profiles.participant.rtps.builtin.discovery_config.discoveryServersList.RemoteServer.metatrafficUnicastLocatorList.locator.udpv6.port = env(DISCOVERY_SERVER_LISTENING_PORT)' $CFG_PATH/superclient_single.xml
             else
                 echo "Error: DISCOVERY_SERVER_LISTENING_PORT value is not a valid number or is greater than or equal to 65535."
                 # Insert other commands here if needed
@@ -116,6 +116,10 @@ create_config_husarnet() {
 
             # Regular expression to match hostname:port or [ipv6addr]:port
             DS_REGEX="^(([a-zA-Z0-9-]+):([0-9]+)|\[(([a-fA-F0-9]{1,4}:){1,7}[a-fA-F0-9]{1,4}|[a-fA-F0-9]{0,4})\]:([0-9]+))$"
+
+            # creating config for super_client
+            cp /superclient.template.xml $CFG_PATH/superclient.xml
+            yq -i '.dds.profiles.participant.rtps.builtin.discovery_config.discoveryServersList.RemoteServer = [ "placeholder1", "placeholder2" ]' $CFG_PATH/superclient.xml
 
             echo "Connecting to:"
             # Loop over Discovery Servers
@@ -194,11 +198,38 @@ create_config_husarnet() {
                             }' $CFG_PATH/DDS_ROUTER_CONFIGURATION_base.yaml
 
                     echo "[$HOST]:$PORT (Server ID: $SERVER_ID)"
+
+                # XML config for client (optional)
+                # # Convert the decimal to a hexadecimal value
+                hex_server_id=$(printf '%.2X' $SERVER_ID)
+
+                # Replace XX in GUID_PREFIX with the hexadecimal value
+                export GUID_PREFIX=$(echo "44.53.XX.5F.45.50.52.4F.53.49.4D.41" | sed "s/XX/$hex_server_id/")
+
+                yq -i '.dds.profiles.participant.rtps.builtin.discovery_config.discoveryServersList.RemoteServer += 
+                        {
+                            "+@prefix": env(GUID_PREFIX),
+                            "metatrafficUnicastLocatorList": 
+                            {
+                                "locator": 
+                                {
+                                    "udpv6": 
+                                    {
+                                        "address": env(HOST),
+                                        "port": env(PORT)
+                                    }
+                                }
+                            }
+                        }' $CFG_PATH/superclient.xml
+
                 else
                     echo "Error: ROS_DISCOVERY_SERVER does not have a valid format: $ds"
                     exit 1
                 fi
             done
+
+            yq -i 'del(.dds.profiles.participant.rtps.builtin.discovery_config.discoveryServersList.RemoteServer[0])' $CFG_PATH/superclient.xml
+            yq -i 'del(.dds.profiles.participant.rtps.builtin.discovery_config.discoveryServersList.RemoteServer[0])' $CFG_PATH/superclient.xml
         else
             yq -i 'del(.participants[1].connection-addresses)' $CFG_PATH/DDS_ROUTER_CONFIGURATION_base.yaml
         fi

--- a/superclient.template.xml
+++ b/superclient.template.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<dds>
+  <profiles xmlns="http://www.eprosima.com/XMLSchemas/fastRTPS_Profiles">
+    <transport_descriptors>
+      <transport_descriptor>
+        <transport_id>HusarnetTransport</transport_id>
+        <type>UDPv6</type>
+      </transport_descriptor>
+    </transport_descriptors>
+    <participant profile_name="client_profile" is_default_profile="true">
+      <rtps>
+        <userTransports>
+          <transport_id>HusarnetTransport</transport_id>
+        </userTransports>
+        <useBuiltinTransports>true</useBuiltinTransports>
+        <defaultUnicastLocatorList>
+          <locator>
+            <udpv6>
+              <address>husarnet-local</address>
+            </udpv6>
+          </locator>
+        </defaultUnicastLocatorList>
+        <builtin>
+          <discovery_config>
+            <discoveryProtocol>SUPER_CLIENT</discoveryProtocol>
+            <discoveryServersList>
+              <RemoteServer prefix="44.53.XX.5F.45.50.52.4F.53.49.4D.41">
+                <metatrafficUnicastLocatorList>
+                  <locator>
+                    <udpv6>
+                      <address>DS_SERVER_IP_PLACEHOLDER</address>
+                      <port>DS_SERVER_PORT_PLACEHOLDER</port>
+                    </udpv6>
+                  </locator>
+                </metatrafficUnicastLocatorList>
+              </RemoteServer>
+            </discoveryServersList>
+          </discovery_config>
+        </builtin>
+      </rtps>
+    </participant>
+  </profiles>
+</dds>


### PR DESCRIPTION
Generating `superclient.xml` config file that can be used (on the host OS level) instead of using `husarnet/ros2router` Docker image on the DDS Discovery Server client side.

Example:

```bash
docker run --rm -it \
  --network host \
  -e ROS_DISCOVERY_SERVER=rosbot2r:11811 \
  -e DISCOVERY_SERVER_ID=10 \
  husarnet/ros2router:1.3.0 \
  cat /var/tmp/superclient.xml | awk '/\?xml version="1.0" encoding="UTF-8" \?/,0' > superclient.xml

export FASTRTPS_DEFAULT_PROFILES_FILE=$(pwd)/superclient.xml
```